### PR TITLE
refactor: added .env file to store API URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/App.js
+++ b/src/App.js
@@ -20,12 +20,10 @@ function App() {
     const fetchData = async () => {
       try {
         const pricePromise = () => {
-          return axios.get(
-            'https://api.coinbase.com/v2/prices/spot?currency=USD'
-          )
+          return axios.get(process.env.REACT_APP_API_PRICE_URL)
         }
         const timePromise = () => {
-          return axios.get('https://api.coinbase.com/v2/time')
+          return axios.get(process.env.REACT_APP_API_TIME_URL)
         }
         await Promise.all([pricePromise(), timePromise()]).then((response) => {
           setPriceData(response[0].data.data.amount)


### PR DESCRIPTION
### Description
Previously... the API URL endpoints for price and time data were stored in the app.js file  
Now... they are stored in a .env file 

### Changes
- Created a .env file and included said file in .gitignore
- Replaced URL endpoints with the environment variables `REACT_APP_API_PRICE_URL` and `REACT_APP_API_TIME_URL` 

### Other comments
- I understand environment variables are accessible through developer tools and is not a secure way to store actual API information/keys
- In a real project I would save API information in a backend server for security purposes
- Also branch should have been named with refactor instead of feat
