### PR TITLE
feat: custom formatting of ISO date

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.1",
+    "dayjs": "^1.10.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,9 @@
 import './App.css'
 import { useState, useEffect } from 'react'
 import axios from 'axios'
+import dayjs from 'dayjs'
+
+dayjs().format()
 
 function App() {
   const [isLoading, setIsLoading] = useState(true)
@@ -27,7 +30,10 @@ function App() {
         }
         await Promise.all([pricePromise(), timePromise()]).then((response) => {
           setPriceData(response[0].data.data.amount)
-          setTimeData(response[1].data.data.iso)
+          let formattedTime = dayjs(response[1].data.data.iso).format(
+            'dddd MMMM D YYYY, h:mm:ss A'
+          )
+          setTimeData(formattedTime)
           setIsLoading(false)
         })
       } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,6 +3860,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
+  integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
### Description
Previously... time data was a string shown in ISO 8601 format
Now... time data is parsed and shown in a more 'human-readable' format 

### Changes
- Added day.js library (moment.js was too big for this task)
- Created `formattedTime` variable to parse and format data before inputting into `setTimeData()`
- Date and time is custom formatted to the following: `'dddd MMMM D YYYY, h:mm:ss A'`

### Other comments
- Chose not to use date() constructor to parse the string as MDN advised browser differences and inconsistencies