### PR TITLE
feat: change currency

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,6 +60,12 @@ function App() {
           <p>as at {timeData}</p>
         </div>
       )}
+      <div>
+        <button>AUD</button>
+        <button>USD</button>
+        <button>EUR</button>
+        <button>GPB</button>
+      </div>
     </div>
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ function App() {
   const [isLoading, setIsLoading] = useState(true)
   const [priceData, setPriceData] = useState()
   const [timeData, setTimeData] = useState()
+  const [currency, setCurrency] = useState('AUD')
 
   useEffect(() => {
     // Set to loading again on each refresh
@@ -19,11 +20,18 @@ function App() {
       fetchData()
     }, 60000)
 
+    const currencyAUD = 'AUD'
+    const currencyUSD = 'USD'
+    const currencyEUR = 'EUR'
+    const currencyGBP = 'GBP'
+
     // Fetch price and time data
     const fetchData = async () => {
       try {
         const pricePromise = () => {
-          return axios.get('https://api.coinbase.com/v2/prices/BTC-USD/spot')
+          return axios.get(
+            `https://api.coinbase.com/v2/prices/BTC-${currency}/spot`
+          )
         }
         const timePromise = () => {
           return axios.get(process.env.REACT_APP_API_TIME_URL)

--- a/src/App.js
+++ b/src/App.js
@@ -60,6 +60,7 @@ function App() {
     }
   }, [currency])
 
+  // Handler for buttons to set currency and currencySymbol state
   const clickHandler = (props) => {
     let currencyCode = props.target.innerText
     setCurrency(currencyCode)
@@ -82,10 +83,18 @@ function App() {
         </div>
       )}
       <div>
-        <button onClick={clickHandler}>AUD</button>
-        <button onClick={clickHandler}>USD</button>
-        <button onClick={clickHandler}>EUR</button>
-        <button onClick={clickHandler}>GBP</button>
+        <button onClick={clickHandler} disabled={currency === 'AUD'}>
+          AUD
+        </button>
+        <button onClick={clickHandler} disabled={currency === 'USD'}>
+          USD
+        </button>
+        <button onClick={clickHandler} disabled={currency === 'EUR'}>
+          EUR
+        </button>
+        <button onClick={clickHandler} disabled={currency === 'GBP'}>
+          GBP
+        </button>
       </div>
     </div>
   )

--- a/src/App.js
+++ b/src/App.js
@@ -40,7 +40,7 @@ function App() {
           return axios.get(process.env.REACT_APP_API_TIME_URL)
         }
         await Promise.all([pricePromise(), timePromise()]).then((response) => {
-          setPriceData(response[0].data.data.amount)
+          setPriceData(Math.round(response[0].data.data.amount * 100) / 100)
           let formattedTime = dayjs(response[1].data.data.iso).format(
             'dddd MMMM D YYYY, h:mm:ss A'
           )

--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,7 @@ function App() {
   const [isLoading, setIsLoading] = useState(true)
   const [priceData, setPriceData] = useState()
   const [timeData, setTimeData] = useState()
-  const [currency, setCurrency] = useState('AUD')
-  const [currencySymbol, setCurrencySymbol] = useState('$')
+  const [currency, setCurrency] = useState({ code: 'AUD', symbol: '$' })
 
   const symbolReference = {
     AUD: '$',
@@ -33,7 +32,7 @@ function App() {
       try {
         const pricePromise = () => {
           return axios.get(
-            `https://api.coinbase.com/v2/prices/BTC-${currency}/spot`
+            `https://api.coinbase.com/v2/prices/BTC-${currency.code}/spot`
           )
         }
         const timePromise = () => {
@@ -62,10 +61,11 @@ function App() {
 
   // Handler for buttons to set currency and currencySymbol state
   const clickHandler = (props) => {
-    let currencyCode = props.target.innerText
-    setCurrency(currencyCode)
-    let currencySymbolCode = symbolReference[currencyCode]
-    setCurrencySymbol(currencySymbolCode)
+    let selectedCurrency = props.target.innerText
+    setCurrency({
+      code: selectedCurrency,
+      symbol: symbolReference[selectedCurrency],
+    })
   }
 
   return (
@@ -76,23 +76,23 @@ function App() {
       ) : (
         <div>
           <p>
-            {currencySymbol}
+            {currency.symbol}
             {priceData}
           </p>
           <p>as at {timeData}</p>
         </div>
       )}
       <div>
-        <button onClick={clickHandler} disabled={currency === 'AUD'}>
+        <button onClick={clickHandler} disabled={currency.code === 'AUD'}>
           AUD
         </button>
-        <button onClick={clickHandler} disabled={currency === 'USD'}>
+        <button onClick={clickHandler} disabled={currency.code === 'USD'}>
           USD
         </button>
-        <button onClick={clickHandler} disabled={currency === 'EUR'}>
+        <button onClick={clickHandler} disabled={currency.code === 'EUR'}>
           EUR
         </button>
-        <button onClick={clickHandler} disabled={currency === 'GBP'}>
+        <button onClick={clickHandler} disabled={currency.code === 'GBP'}>
           GBP
         </button>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,14 @@ function App() {
   const [priceData, setPriceData] = useState()
   const [timeData, setTimeData] = useState()
   const [currency, setCurrency] = useState('AUD')
+  const [currencySymbol, setCurrencySymbol] = useState('$')
+
+  const symbolReference = {
+    AUD: '$',
+    USD: '$',
+    EUR: '€',
+    GBP: '£',
+  }
 
   useEffect(() => {
     // Set to loading again on each refresh
@@ -55,6 +63,8 @@ function App() {
   const clickHandler = (props) => {
     let currencyCode = props.target.innerText
     setCurrency(currencyCode)
+    let currencySymbolCode = symbolReference[currencyCode]
+    setCurrencySymbol(currencySymbolCode)
   }
 
   return (
@@ -64,7 +74,10 @@ function App() {
         <div>Loading ...</div>
       ) : (
         <div>
-          <p>{priceData}</p>
+          <p>
+            {currencySymbol}
+            {priceData}
+          </p>
           <p>as at {timeData}</p>
         </div>
       )}

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ function App() {
     const fetchData = async () => {
       try {
         const pricePromise = () => {
-          return axios.get(process.env.REACT_APP_API_PRICE_URL)
+          return axios.get('https://api.coinbase.com/v2/prices/BTC-USD/spot')
         }
         const timePromise = () => {
           return axios.get(process.env.REACT_APP_API_TIME_URL)

--- a/src/App.js
+++ b/src/App.js
@@ -20,11 +20,6 @@ function App() {
       fetchData()
     }, 60000)
 
-    const currencyAUD = 'AUD'
-    const currencyUSD = 'USD'
-    const currencyEUR = 'EUR'
-    const currencyGBP = 'GBP'
-
     // Fetch price and time data
     const fetchData = async () => {
       try {
@@ -55,7 +50,12 @@ function App() {
     return () => {
       clearInterval(interval)
     }
-  }, [])
+  }, [currency])
+
+  const clickHandler = (props) => {
+    let currencyCode = props.target.innerText
+    setCurrency(currencyCode)
+  }
 
   return (
     <div>
@@ -69,10 +69,10 @@ function App() {
         </div>
       )}
       <div>
-        <button>AUD</button>
-        <button>USD</button>
-        <button>EUR</button>
-        <button>GPB</button>
+        <button onClick={clickHandler}>AUD</button>
+        <button onClick={clickHandler}>USD</button>
+        <button onClick={clickHandler}>EUR</button>
+        <button onClick={clickHandler}>GBP</button>
       </div>
     </div>
   )


### PR DESCRIPTION
### Description
Previously...price would only be displayed in USD by default. 
Now...users can select from AUD, USD, EUR, GBP and displays the AUD price by default.

### Changes
- Created `currency` state with `useState()` hook to store currency code (used in API link) and currency symbol
- The `currency` state is set when the currency buttons are clicked 
- Pulls the correct symbol from an object `symbolReference` which has each symbol using currency codes as key
- Rounded the price response from Coinbase to 2 decimal points as AUD was displayed with 5+ decimal points
- Updated link to Coinbase's new API endpoint (not using .env file for now)

### Other comments
- May be more appropriate to truncate the price instead of rounding